### PR TITLE
chore: run ruff and black

### DIFF
--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from hello import main
+from hello import main  # noqa: E402
 
 
 def test_main_prints_hello(capsys):


### PR DESCRIPTION
## Summary
- silence ruff import error in tests

## Testing
- `ruff check . --fix`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6dd8ad84c832baf2f09c312801487